### PR TITLE
Adds markdown image loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /captures
 .externalNativeBuild
 .cxx
+app/release

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,10 +82,15 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.1.0'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.1.0'
     implementation 'androidx.navigation:navigation-ui-ktx:2.1.0'
-    implementation "androidx.paging:paging-runtime:2.1.0"
-    implementation "com.google.android.material:material:1.1.0-alpha10"
+    implementation "androidx.paging:paging-runtime:2.1.1"
+    implementation "com.google.android.material:material:1.2.0-alpha02"
 
-    implementation "io.noties.markwon:core:4.1.1"
+    implementation "io.noties.markwon:core:4.2.0"
+    implementation "io.noties.markwon:image:4.2.0"
+    implementation "io.noties.markwon:image-glide:4.2.0"
+
+    implementation 'com.github.bumptech.glide:glide:4.10.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.10.0'
 
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.2'

--- a/app/gosbot-sources.jar
+++ b/app/gosbot-sources.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8b8993790e018fb7fa39f5fffac1c918ab853f92000cfc6b54a621337f8e7d17
-size 6551
+oid sha256:b2bdae0537d10d91a3ef5c01cea45b5a06500afd5b38651792ef414c2ba1eadd
+size 6566

--- a/app/gosbot.aar
+++ b/app/gosbot.aar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a6b8dde395023bfac65666ef1759bcdb3a3d3f6cc434a7ec0d8f264af65b9bbe
-size 54976700
+oid sha256:71f852d4ab419d371359e230b774ace0dbaafbef18bdc4b21aade370e63a59a0
+size 55032647

--- a/app/gosbot.aar
+++ b/app/gosbot.aar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d1967b89196f1da3a7c363c372002c0e16659b03d6b229da6ba9c2a26f742c6d
-size 53618446
+oid sha256:a6b8dde395023bfac65666ef1759bcdb3a3d3f6cc434a7ec0d8f264af65b9bbe
+size 54976700

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:networkSecurityConfig="@xml/network_security_config"
         android:name=".ScuttlebuttApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/social/sunrise/app/ScuttlebuttApp.kt
+++ b/app/src/main/java/social/sunrise/app/ScuttlebuttApp.kt
@@ -7,6 +7,7 @@ import android.graphics.drawable.Drawable
 import androidx.navigation.findNavController
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestBuilder
+import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.request.target.Target
 import com.sunrisechoir.patchql.Params
 import com.sunrisechoir.patchql.PatchqlApollo
@@ -148,6 +149,7 @@ class ScuttlebuttApp : Application(), KodeinAware {
 
                 }
             }
+            val glideOptions = RequestOptions().timeout(25000)
 
             val glideStore = object : GlideImagesPlugin.GlideStore {
                 override fun load(drawable: AsyncDrawable): RequestBuilder<Drawable> {
@@ -163,7 +165,10 @@ class ScuttlebuttApp : Application(), KodeinAware {
             Markwon.builder(applicationContext)
                 .usePlugin(plugin)
                 .usePlugin(GlideImagesPlugin.create(applicationContext))
-                .usePlugin(GlideImagesPlugin.create(Glide.with(applicationContext)))
+                .usePlugin(GlideImagesPlugin.create(Glide
+                    .with(applicationContext)
+                    .applyDefaultRequestOptions(glideOptions)
+                    ))
                 .usePlugin(GlideImagesPlugin.create(glideStore))
                 .build()
         }

--- a/app/src/main/java/social/sunrise/app/ScuttlebuttApp.kt
+++ b/app/src/main/java/social/sunrise/app/ScuttlebuttApp.kt
@@ -3,14 +3,21 @@ package social.sunrise.app
 
 import android.app.Application
 import android.content.Context
+import android.graphics.drawable.Drawable
 import androidx.navigation.findNavController
+import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestBuilder
+import com.bumptech.glide.request.target.Target
 import com.sunrisechoir.patchql.Params
 import com.sunrisechoir.patchql.PatchqlApollo
 import gobotexample.Gobotexample
 import io.noties.markwon.AbstractMarkwonPlugin
 import io.noties.markwon.LinkResolverDef
 import io.noties.markwon.Markwon
+
 import io.noties.markwon.MarkwonConfiguration
+import io.noties.markwon.image.AsyncDrawable
+import io.noties.markwon.image.glide.GlideImagesPlugin
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.serialization.Serializable
@@ -24,6 +31,7 @@ import social.sunrise.app.database.Database
 import social.sunrise.app.models.PatchqlBackgroundMessage
 import social.sunrise.app.utils.SsbUri
 import java.io.File
+import java.net.URLEncoder
 
 
 @Serializable
@@ -33,6 +41,8 @@ data class Secret(val id: String, val private: String, val curve: String, val pu
 class ScuttlebuttApp : Application(), KodeinAware {
 
     override val kodein: Kodein by Kodein.lazy {
+
+        val blobServerUrl = "http://127.0.0.1:8091/blobs/"
 
         val externalDir = getDir("scuttlebutt", Context.MODE_PRIVATE).absolutePath
         val repoPath = externalDir + getString(R.string.ssb_go_folder_name)
@@ -138,14 +148,28 @@ class ScuttlebuttApp : Application(), KodeinAware {
 
                 }
             }
+
+            val glideStore = object : GlideImagesPlugin.GlideStore {
+                override fun load(drawable: AsyncDrawable): RequestBuilder<Drawable> {
+                    val urlEncodedBlob = URLEncoder.encode(drawable.destination, "US-ASCII")
+                    val destination = blobServerUrl + urlEncodedBlob
+                    return Glide.with(applicationContext).load(destination)
+                }
+
+                override fun cancel(target: Target<*>) {
+                    Glide.with(applicationContext).clear(target)
+                }
+            }
             Markwon.builder(applicationContext)
                 .usePlugin(plugin)
+                .usePlugin(GlideImagesPlugin.create(applicationContext))
+                .usePlugin(GlideImagesPlugin.create(Glide.with(applicationContext)))
+                .usePlugin(GlideImagesPlugin.create(glideStore))
                 .build()
         }
 
         constant("repoPath") with repoPath
         constant("mySsbIdentity") with pubKey
-
     }
 
 

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">127.0.0.1</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
- related to [this pr in the go code](https://github.com/sunrise-choir/sunrise-social-gobot/pull/2)
- image loading is kinda "one shot", if the server had the image at that particular moment, you get it, if not, it's not displayed. This comes from the go side. If we can fix it in go then we'll have async image loading which would be way better.
- gifs don't seem to animate

![Screenshot_20191222-161029](https://user-images.githubusercontent.com/10556538/71323911-d5662b00-24d8-11ea-853f-b4ad747cf508.jpg)
