### PR TITLE
Searches can fail if the query has too many results.

### DIFF
--- a/app/src/main/java/social/sunrise/app/database/post/PostDaoImpl.kt
+++ b/app/src/main/java/social/sunrise/app/database/post/PostDaoImpl.kt
@@ -59,7 +59,6 @@ class PostDaoImpl(
             var mutableLiveData: MutableLiveData<PostsDataSource> = MutableLiveData()
             private lateinit var postsDataSource: PostsDataSource
 
-
             override fun create(): DataSource<String, LiveData<Post>> {
 
                 postsDataSource = PostsDataSource(

--- a/app/src/main/java/social/sunrise/app/database/post/PostDataSource.kt
+++ b/app/src/main/java/social/sunrise/app/database/post/PostDataSource.kt
@@ -48,10 +48,10 @@ class PostsDataSource(
             .build()
 
         patchqlApollo.query(PostsQuery) {
-            it.map(::responseIntoPosts)
+            it.mapCatching(::responseIntoPosts)
                 .onSuccess(callback::onResult)
                 .onFailure {
-                    throw Error("patchql query failed. ${it}")
+
                 }
         }
     }
@@ -67,15 +67,19 @@ class PostsDataSource(
             .build()
 
         patchqlApollo.query(PostsQuery) {
-            it.map(::responseIntoPosts)
+            it.mapCatching(::responseIntoPosts)
                 .onSuccess(callback::onResult)
                 .onFailure {
-                    throw Error("patchql query failed. ${it}")
+
                 }
         }
     }
 
     private fun responseIntoPosts(it: Response<*>): List<LiveData<Post>> {
+
+        if (it.data() == null) {
+            throw Exception("Couldn't get a response from posts")
+        }
         val data = it.data() as PostsQuery.Data
 
         return data.posts().edges().map { edge ->


### PR DESCRIPTION
Fixes #5 

So far this PR quietly swallows the error. I'd like to display something useful in the UI when this happens though. I can't see an easy way to fix this right now. I'm keen to merge this sooner rather than later because having the app just crash is pretty bad.